### PR TITLE
Delete account with S P *.

### DIFF
--- a/dgraph/src/jepsen/dgraph/bank.clj
+++ b/dgraph/src/jepsen/dgraph/bank.clj
@@ -84,8 +84,18 @@
   "Writes back an account map."
   [t account]
   (t/with-trace "write-account"
-    ; (if (zero? (:amount account))
-    ;   (c/delete! t (assert+ (:uid account)))
+    (if (zero? (:amount account))
+      (let [k (assert+ (:key account))
+            kp (c/gen-pred "key"    pred-count k)
+            ap (c/gen-pred "amount" pred-count k)
+            tp (c/gen-pred "type"   pred-count k)]
+        (t/attribute! "delete" "true")
+        (c/delete! t [{:uid (assert+ (:uid account)),
+                       (assoc (keyword tp) nil)},
+                      {:uid (assert+ (:uid account)),
+                       (assoc (keyword kp) nil)},
+                      {:uid (assert+ (:uid account)),
+                       (assoc (keyword ap) nil)}]))
       (let [k (assert+ (:key account))
             kp (c/gen-pred "key"    pred-count k)
             ap (c/gen-pred "amount" pred-count k)

--- a/dgraph/src/jepsen/dgraph/bank.clj
+++ b/dgraph/src/jepsen/dgraph/bank.clj
@@ -89,13 +89,11 @@
           ap (c/gen-pred "amount" pred-count k)
           tp (c/gen-pred "type"   pred-count k)]
       (if (zero? (:amount account))
-        (do
-          (t/attribute! "delete" "true")
-          (c/delete! t (-> account
-                           (select-keys [:uid])
-                           (assoc (keyword tp) nil),
-                           (assoc (keyword kp) nil),
-                           (assoc (keyword ap) nil))))
+        (c/delete! t (-> account
+                         (select-keys [:uid])
+                         (assoc (keyword tp) nil),
+                         (assoc (keyword kp) nil),
+                         (assoc (keyword ap) nil)))
         (c/mutate! t (-> account
                          (select-keys [:uid])
                          (assoc (keyword tp) (:type account))

--- a/dgraph/src/jepsen/dgraph/bank.clj
+++ b/dgraph/src/jepsen/dgraph/bank.clj
@@ -84,27 +84,23 @@
   "Writes back an account map."
   [t account]
   (t/with-trace "write-account"
-    (if (zero? (:amount account))
-      (let [k (assert+ (:key account))
-            kp (c/gen-pred "key"    pred-count k)
-            ap (c/gen-pred "amount" pred-count k)
-            tp (c/gen-pred "type"   pred-count k)]
-        (t/attribute! "delete" "true")
-        (c/delete! t [{:uid (assert+ (:uid account)),
-                       (assoc (keyword tp) nil)},
-                      {:uid (assert+ (:uid account)),
-                       (assoc (keyword kp) nil)},
-                      {:uid (assert+ (:uid account)),
-                       (assoc (keyword ap) nil)}]))
-      (let [k (assert+ (:key account))
-            kp (c/gen-pred "key"    pred-count k)
-            ap (c/gen-pred "amount" pred-count k)
-            tp (c/gen-pred "type"   pred-count k)]
+    (let [k (assert+ (:key account))
+          kp (c/gen-pred "key"    pred-count k)
+          ap (c/gen-pred "amount" pred-count k)
+          tp (c/gen-pred "type"   pred-count k)]
+      (if (zero? (:amount account))
+        (do
+          (t/attribute! "delete" "true")
+          (c/delete! t (-> account
+                           (select-keys [:uid])
+                           (assoc (keyword tp) nil),
+                           (assoc (keyword kp) nil),
+                           (assoc (keyword ap) nil))))
         (c/mutate! t (-> account
                          (select-keys [:uid])
                          (assoc (keyword tp) (:type account))
                          (assoc (keyword kp) (:key account))
-                         (assoc (keyword ap) (:amount account)))))))
+                         (assoc (keyword ap) (:amount account))))))))
 
 (defrecord Client [conn]
   client/Client


### PR DESCRIPTION
This deletes account nodes with `S P *` instead of the original `S * *` and the workaround of `S <amount> 0`.

In Jaeger, filter by jepsen -> client.delete! operation to find these traces.