### PR TITLE
Show Dgraph version in test reports when using a local binary.

### DIFF
--- a/dgraph/src/jepsen/dgraph/core.clj
+++ b/dgraph/src/jepsen/dgraph/core.clj
@@ -2,6 +2,7 @@
   (:gen-class)
   (:require [clojure.string :as str]
             [clojure.tools.logging :refer [info warn]]
+            [clojure.java.shell :refer [sh]]
             [clojure.pprint :refer [pprint]]
             [jepsen [cli :as cli]
                     [core :as jepsen]
@@ -56,7 +57,10 @@
   "Builds up a dgraph test map from CLI options."
   [opts]
   (let [version  (if (:local-binary opts)
-                   "unknown"
+                   (let [v (:out (sh (:local-binary opts) "version"))]
+                     (if-let [m (re-find #"Dgraph version   : (v[0-9a-z\.-]+)" v)]
+                       (m 1)
+                       "unknown"))
                    (if-let [p (:package-url opts)]
                      (if-let [m (re-find #"([^/]+)/[^/.]+\.tar\.gz" p)]
                        (m 1)


### PR DESCRIPTION
Instead of showing "dgraph unknown" in the test results this would get the Dgraph version from `dgraph version`.

![2019-03-12-173424_971x47_scrot](https://user-images.githubusercontent.com/2251820/54245207-1f06fb80-44ed-11e9-80eb-93ec8eb3b683.png)

Even better would be to also put the branch in the version name. But IIRC when I tried that I got a datetime format error when going to the test result page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/jepsen/2)
<!-- Reviewable:end -->
