### PR TITLE
Set jepsen version to 0.1.15 for dgraph tests.

### DIFF
--- a/dgraph/project.clj
+++ b/dgraph/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.0"]
-                 [jepsen "0.1.16-SNAPSHOT"]
+                 [jepsen "0.1.15"]
                  [clj-http "3.7.0"]
                  [cheshire "5.8.0"]
                  [clj-wallhack "1.0.1"]


### PR DESCRIPTION
This change downgrades Dgraph test project to Jepsen version 0.1.15 so the tests can run with Dgraph v1.1.1-rc2.

Dgraph v1.1.1-rc2 does not run with the current jepsen 0.1.16-SNAPSHOT (at the time of this writing, up to this commit: https://github.com/jepsen-io/jepsen/commit/c2712cdd58a5ab03f8ce9696a2f54709d6ab8a17). With 0.1.16-SNAPSHOT, this error happens:

```
$ docker exec jepsen-control /bin/bash -c "source ~/.bashrc && cd /jepsen/dgraph && lein run test --workload bank --nemesis none --time-limit 60 --concurrency 6n --rebalance-interval 10h --local-binary /gobin/dgraph --nodes n1,n2,n3,n4,n5 --test-count 1 --dgraph-jaeger-collector http://jaeger:14268 --tracing http://jaeger:14268/api/traces"
Welcome to Jepsen on Docker
===========================

This container runs the Jepsen tests in sub-containers.

You are currently in the base dir of the git repo for Jepsen.
If you modify the core jepsen library make sure you "lein install" it so other tests can access.

To run a test:
   cd etcd && lein run test --concurrency 10
Retrieving jepsen/jepsen/0.1.16-SNAPSHOT/jepsen-0.1.16-20191121.184917-3.pom from clojars
Retrieving knossos/knossos/0.3.6-SNAPSHOT/knossos-0.3.6-20191205.151521-1.pom from clojars
Retrieving org/clojure/core.rrb-vector/0.0.13/core.rrb-vector-0.0.13.pom from central
Retrieving knossos/knossos/0.3.6-SNAPSHOT/knossos-0.3.6-20191205.151521-1.jar from clojars
Retrieving jepsen/jepsen/0.1.16-SNAPSHOT/jepsen-0.1.16-20191121.184917-3.jar from clojars
Retrieving org/clojure/core.rrb-vector/0.0.13/core.rrb-vector-0.0.13.jar from central
Retrieving fipp/fipp/0.6.14/fipp-0.6.14.jar from clojars
WARNING: Process already refers to: class java.lang.Process in namespace: jepsen.db, being replaced by: #'jepsen.db/Process
Exception in thread "main" Syntax error compiling at (jepsen/dgraph/core.clj:1:1).
	at clojure.lang.Compiler.load(Compiler.java:7647)
	at clojure.lang.RT.loadResourceScript(RT.java:381)
	at clojure.lang.RT.loadResourceScript(RT.java:372)
	at clojure.lang.RT.load(RT.java:463)
	at clojure.lang.RT.load(RT.java:428)
	at clojure.core$load$fn__6824.invoke(core.clj:6126)
	at clojure.core$load.invokeStatic(core.clj:6125)
	at clojure.core$load.doInvoke(core.clj:6109)
	at clojure.lang.RestFn.invoke(RestFn.java:408)
	at clojure.core$load_one.invokeStatic(core.clj:5908)
	at clojure.core$load_one.invoke(core.clj:5903)
	at clojure.core$load_lib$fn__6765.invoke(core.clj:5948)
	at clojure.core$load_lib.invokeStatic(core.clj:5947)
	at clojure.core$load_lib.doInvoke(core.clj:5928)
	at clojure.lang.RestFn.applyTo(RestFn.java:142)
	at clojure.core$apply.invokeStatic(core.clj:667)
	at clojure.core$load_libs.invokeStatic(core.clj:5985)
	at clojure.core$load_libs.doInvoke(core.clj:5969)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.core$apply.invokeStatic(core.clj:667)
	at clojure.core$require.invokeStatic(core.clj:6007)
	at clojure.core$require.doInvoke(core.clj:6007)
	at clojure.lang.RestFn.invoke(RestFn.java:408)
	at user$eval140$fn__144.invoke(form-init6085116236533245047.clj:1)
	at user$eval140.invokeStatic(form-init6085116236533245047.clj:1)
	at user$eval140.invoke(form-init6085116236533245047.clj:1)
	at clojure.lang.Compiler.eval(Compiler.java:7176)
	at clojure.lang.Compiler.eval(Compiler.java:7166)
	at clojure.lang.Compiler.load(Compiler.java:7635)
	at clojure.lang.Compiler.loadFile(Compiler.java:7573)
	at clojure.main$load_script.invokeStatic(main.clj:452)
	at clojure.main$init_opt.invokeStatic(main.clj:454)
	at clojure.main$init_opt.invoke(main.clj:454)
	at clojure.main$initialize.invokeStatic(main.clj:485)
	at clojure.main$null_opt.invokeStatic(main.clj:519)
	at clojure.main$null_opt.invoke(main.clj:516)
	at clojure.main$main.invokeStatic(main.clj:598)
	at clojure.main$main.doInvoke(main.clj:561)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.lang.Var.applyTo(Var.java:705)
	at clojure.main.main(main.java:37)
Caused by: java.lang.ExceptionInInitializerError
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:348)
	at clojure.lang.RT.classForName(RT.java:2207)
	at clojure.lang.RT.classForName(RT.java:2216)
	at clojure.lang.RT.loadClassForName(RT.java:2235)
	at clojure.lang.RT.load(RT.java:453)
	at clojure.lang.RT.load(RT.java:428)
	at clojure.core$load$fn__6824.invoke(core.clj:6126)
	at clojure.core$load.invokeStatic(core.clj:6125)
	at clojure.core$load.doInvoke(core.clj:6109)
	at clojure.lang.RestFn.invoke(RestFn.java:408)
	at clojure.core$load_one.invokeStatic(core.clj:5908)
	at clojure.core$load_one.invoke(core.clj:5903)
	at clojure.core$load_lib$fn__6765.invoke(core.clj:5948)
	at clojure.core$load_lib.invokeStatic(core.clj:5947)
	at clojure.core$load_lib.doInvoke(core.clj:5928)
	at clojure.lang.RestFn.applyTo(RestFn.java:142)
	at clojure.core$apply.invokeStatic(core.clj:667)
	at clojure.core$load_libs.invokeStatic(core.clj:5985)
	at clojure.core$load_libs.doInvoke(core.clj:5969)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.core$apply.invokeStatic(core.clj:667)
	at clojure.core$require.invokeStatic(core.clj:6007)
	at clojure.core$require.doInvoke(core.clj:6007)
	at clojure.lang.RestFn.invoke(RestFn.java:2793)
	at jepsen.core$loading__6706__auto____289.invoke(core.clj:1)
	at jepsen.core__init.load(Unknown Source)
	at jepsen.core__init.<clinit>(Unknown Source)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:348)
	at clojure.lang.RT.classForName(RT.java:2207)
	at clojure.lang.RT.classForName(RT.java:2216)
	at clojure.lang.RT.loadClassForName(RT.java:2235)
	at clojure.lang.RT.load(RT.java:453)
	at clojure.lang.RT.load(RT.java:428)
	at clojure.core$load$fn__6824.invoke(core.clj:6126)
	at clojure.core$load.invokeStatic(core.clj:6125)
	at clojure.core$load.doInvoke(core.clj:6109)
	at clojure.lang.RestFn.invoke(RestFn.java:408)
	at clojure.core$load_one.invokeStatic(core.clj:5908)
	at clojure.core$load_one.invoke(core.clj:5903)
	at clojure.core$load_lib$fn__6765.invoke(core.clj:5948)
	at clojure.core$load_lib.invokeStatic(core.clj:5947)
	at clojure.core$load_lib.doInvoke(core.clj:5928)
	at clojure.lang.RestFn.applyTo(RestFn.java:142)
	at clojure.core$apply.invokeStatic(core.clj:667)
	at clojure.core$load_libs.invokeStatic(core.clj:5989)
	at clojure.core$load_libs.doInvoke(core.clj:5969)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.core$apply.invokeStatic(core.clj:667)
	at clojure.core$require.invokeStatic(core.clj:6007)
	at clojure.core$require.doInvoke(core.clj:6007)
	at clojure.lang.RestFn.invoke(RestFn.java:551)
	at jepsen.cli$loading__6706__auto____171.invoke(cli.clj:1)
	at jepsen.cli__init.load(Unknown Source)
	at jepsen.cli__init.<clinit>(Unknown Source)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:348)
	at clojure.lang.RT.classForName(RT.java:2207)
	at clojure.lang.RT.classForName(RT.java:2216)
	at clojure.lang.RT.loadClassForName(RT.java:2235)
	at clojure.lang.RT.load(RT.java:453)
	at clojure.lang.RT.load(RT.java:428)
	at clojure.core$load$fn__6824.invoke(core.clj:6126)
	at clojure.core$load.invokeStatic(core.clj:6125)
	at clojure.core$load.doInvoke(core.clj:6109)
	at clojure.lang.RestFn.invoke(RestFn.java:408)
	at clojure.core$load_one.invokeStatic(core.clj:5908)
	at clojure.core$load_one.invoke(core.clj:5903)
	at clojure.core$load_lib$fn__6765.invoke(core.clj:5948)
	at clojure.core$load_lib.invokeStatic(core.clj:5947)
	at clojure.core$load_lib.doInvoke(core.clj:5928)
	at clojure.lang.RestFn.applyTo(RestFn.java:142)
	at clojure.core$apply.invokeStatic(core.clj:667)
	at clojure.core$load_libs.invokeStatic(core.clj:5989)
	at clojure.core$load_libs.doInvoke(core.clj:5969)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.core$apply.invokeStatic(core.clj:667)
	at clojure.core$require.invokeStatic(core.clj:6007)
	at clojure.core$require.doInvoke(core.clj:6007)
	at clojure.lang.RestFn.invoke(RestFn.java:619)
	at jepsen.dgraph.core$eval157$loading__6706__auto____158.invoke(core.clj:1)
	at jepsen.dgraph.core$eval157.invokeStatic(core.clj:1)
	at jepsen.dgraph.core$eval157.invoke(core.clj:1)
	at clojure.lang.Compiler.eval(Compiler.java:7176)
	at clojure.lang.Compiler.eval(Compiler.java:7165)
	at clojure.lang.Compiler.load(Compiler.java:7635)
	... 40 more
Caused by: java.lang.ClassCastException: clojure.lang.Var$Unbound cannot be cast to clojure.lang.IPersistentCollection
	at clojure.core$conj__5375.invokeStatic(core.clj:82)
	at clojure.core$merge$fn__5943.invoke(core.clj:3049)
	at clojure.core$reduce1.invokeStatic(core.clj:944)
	at clojure.core$reduce1.invokeStatic(core.clj:934)
	at clojure.core$merge.invokeStatic(core.clj:3048)
	at clojure.core$merge.doInvoke(core.clj:3041)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.lang.Var.alterRoot(Var.java:308)
	at clojure.core$alter_var_root.invokeStatic(core.clj:5510)
	at clojure.core$alter_var_root.doInvoke(core.clj:5505)
	at clojure.lang.RestFn.invoke(RestFn.java:442)
	at jepsen.db__init.load(Unknown Source)
	at jepsen.db__init.<clinit>(Unknown Source)
	... 127 more
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/jepsen/10)
<!-- Reviewable:end -->
