### PR TITLE
Use Badger storage for Jaeger traces.

### DIFF
--- a/dgraph/docker/docker-compose.yml
+++ b/dgraph/docker/docker-compose.yml
@@ -6,23 +6,27 @@ services:
   jaeger:
     networks:
       - jepsen
-    image: jaegertracing/all-in-one:latest
+    image: jaegertracing/all-in-one:1.16
     container_name: jaeger
     hostname: jaeger
     ports:
-      - "5775:5775/udp"
-      - "6831:6831/udp"
-      - "6832:6832/udp"
-      - "5778:5778"
-      - "16686:16686"
-      - "14268:14268"
-      - "9411:9411"
+      - "16686:16686" # UI
+      - "14268:14268" # Collector
+      - "14269:14269" # Admin endpoint for metrics & pprof
+    volumes:
+      - type: bind
+        source: .
+        target: /working
     environment:
-      - COLLECTOR_ZIPKIN_HTTP_PORT=9411
+      - SPAN_STORAGE_TYPE=badger
+      - BADGER_EPHEMERAL=false
+      - BADGER_DIRECTORY_KEY=/working/jaeger
+      - BADGER_DIRECTORY_VALUE=/working/jaeger
+      - BADGER_SPAN_STORE_TTL=30d
   grafana:
     networks:
       - jepsen
-    image: grafana/grafana
+    image: grafana/grafana:6.5.3
     container_name: grafana
     hostname: grafana
     environment:
@@ -38,7 +42,7 @@ services:
   node-exporter:
     networks:
       - jepsen
-    image: quay.io/prometheus/node-exporter
+    image: quay.io/prometheus/node-exporter:v0.18.1
     container_name: node-exporter
     pid: host
     working_dir: /working/jaeger
@@ -50,7 +54,7 @@ services:
   prometheus:
     networks:
       - jepsen
-    image: prom/prometheus
+    image: prom/prometheus:v2.15.1
     container_name: prometheus
     hostname: prometheus
     ports:

--- a/dgraph/docker/docker-compose.yml
+++ b/dgraph/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - BADGER_EPHEMERAL=false
       - BADGER_DIRECTORY_KEY=/working/jaeger
       - BADGER_DIRECTORY_VALUE=/working/jaeger
-      - BADGER_SPAN_STORE_TTL=0
+      - BADGER_SPAN_STORE_TTL=87600h
   grafana:
     networks:
       - jepsen

--- a/dgraph/docker/docker-compose.yml
+++ b/dgraph/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - BADGER_EPHEMERAL=false
       - BADGER_DIRECTORY_KEY=/working/jaeger
       - BADGER_DIRECTORY_VALUE=/working/jaeger
-      - BADGER_SPAN_STORE_TTL=30d
+      - BADGER_SPAN_STORE_TTL=0
   grafana:
     networks:
       - jepsen

--- a/dgraph/docker/docker-compose.yml
+++ b/dgraph/docker/docker-compose.yml
@@ -13,10 +13,6 @@ services:
       - "16686:16686" # UI
       - "14268:14268" # Collector
       - "14269:14269" # Admin endpoint for metrics & pprof
-    volumes:
-      - type: bind
-        source: .
-        target: /working
     environment:
       - SPAN_STORAGE_TYPE=badger
       - BADGER_EPHEMERAL=false


### PR DESCRIPTION
* Use Badger storage option for Jaeger.
  * Spans are persisted on disk on the host in ./docker/jaeger.
  * Span storage TTL is set to 10 years.
  * Expose only ports 16686 (UI), 14268 (Collector), and 14269 (Admin).
* Version-lock all services (Jaeger, Grafana, Prometheus, Node Exporter).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/jepsen/11)
<!-- Reviewable:end -->
