### PR TITLE
Retry alter after any error

### DIFF
--- a/dgraph/src/jepsen/dgraph/client.clj
+++ b/dgraph/src/jepsen/dgraph/client.clj
@@ -270,6 +270,7 @@
           (if (and (< 0 i)
                    (or (re-find #"DEADLINE_EXCEEDED" message)
                        (re-find #"Pending transactions" message)
+                       (re-find #"is already running" message)
                        (re-find #"ABORTED" message)))
             (do
               (warn "alter-schema! failed due to retriable error, retrying...")

--- a/dgraph/src/jepsen/dgraph/client.clj
+++ b/dgraph/src/jepsen/dgraph/client.clj
@@ -254,10 +254,9 @@
 
 (defn alter-schema!
   "Takes a schema string (or any number of strings) and applies that alteration
-  to dgraph. Retries if DEADLINE_EXCEEDED, or Dgraph complains about pending
-  transactions, or just tells us the alter ABORTED, since Dgraph likes to throw
-  these for ??? reasons at the start of the test. Should be idempotent, so...
-  hopefully we can retry, at least in this context?"
+  to dgraph. Retries if the alter fails. There are too many different types of
+  failures so we retry all to avoid missing any. Alters are idempotent so retrying
+  should not be an issue."
   [^DgraphClient client & schemata]
   (t/with-trace "client.alter-schema!"
     (with-retry [i 10]


### PR DESCRIPTION
Currently, alter operations are retried if the exception message matches an approved message.

However, changes in Dgraph change the retrieable errors and they often lead to failures
in jepsen. The latest changes to track operations result in a lot of interrupted exceptions,
some of which have empty messages. This makes it hard to maintain jepsen and requires
changes in the Java client.

Rather than check for an error message, retry all the alter operations for better reliability
and to prevent changes in Dgraph from breaking the testing suite.
The only alter operations that should fail are those where the schema is wrong but the
schema used in this test is not changed very often.

This fix applies to all workloads, although the issue seems to happen more often in some.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/jepsen/12)
<!-- Reviewable:end -->
