### PR TITLE
fix jepsen test failure after IP whitelisting in dgraph

### DIFF
--- a/dgraph/src/jepsen/dgraph/support.clj
+++ b/dgraph/src/jepsen/dgraph/support.clj
@@ -105,6 +105,7 @@
           :--expose_trace
           :--v 2
           :--vmodule=groups=3 ;; flag to set -v=3 for worker/groups.go
+          "--whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
           (when (:dgraph-jaeger-collector test)
             [:--jaeger.collector (:dgraph-jaeger-collector test)])
           (when (:dgraph-jaeger-agent test)


### PR DESCRIPTION
This PR fixes jepsen test failure resulting as a result of adding IP whitelisting in `/alter`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/jepsen/13)
<!-- Reviewable:end -->
