### PR TITLE
fix: Match Dgraph version strings with capital letters.

### DIFF
--- a/dgraph/src/jepsen/dgraph/core.clj
+++ b/dgraph/src/jepsen/dgraph/core.clj
@@ -92,7 +92,7 @@
                    ; look for them in $PATH, not the working directory
                    (let [bin (.getCanonicalPath (io/file bin))
                          v   (:out (sh bin "version"))]
-                     (if-let [m (re-find #"Dgraph version   : (v[0-9a-z\.-]+)" v)]
+                     (if-let [m (re-find #"Dgraph version   : (v[0-9a-zA-Z\.-]+)" v)]
                        (m 1)
                        "unknown"))
                    (if-let [p (:package-url opts)]


### PR DESCRIPTION
Beta versions of Dgraph can have capital letters, e.g., "Jun" in
"v20.07.0-beta.Jun15".

Before:
![jepsen-before](https://user-images.githubusercontent.com/2251820/87212880-c0ff4980-c2d5-11ea-9ec4-0ceb1e51f3c4.png)

After:
![jepsen-after](https://user-images.githubusercontent.com/2251820/87212884-c5c3fd80-c2d5-11ea-9858-09180528f982.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/jepsen/14)
<!-- Reviewable:end -->
