### PR TITLE
fix(deps): update old dependencies

### DIFF
--- a/dgraph/project.clj
+++ b/dgraph/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.0"]
-                 [jepsen "0.1.17"]
+                 [jepsen "0.1.18"]
                  [clj-http "3.7.0"]
                  [cheshire "5.8.0"]
                  [clj-wallhack "1.0.1"]

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,5 +1,5 @@
 # Based on the deprecated `https://github.com/tutumcloud/tutum-debian`
-FROM debian:stretch
+FROM debian:buster
 
 # Install packages
 RUN apt-get update && \
@@ -23,7 +23,7 @@ RUN apt install -y apt-transport-https
 RUN apt install -y software-properties-common
 
 # Install Jepsen deps
-RUN apt-get install -y build-essential bzip2 curl faketime iproute iptables iputils-ping libzip4 logrotate man man-db net-tools ntpdate psmisc python rsyslog sudo tar unzip vim wget && apt-get remove -y --purge --auto-remove systemd
+RUN apt-get install -y build-essential bzip2 curl faketime iproute2 iptables iputils-ping libzip4 logrotate man man-db net-tools ntpdate psmisc python rsyslog sudo tar unzip vim wget && apt-get remove -y --purge --auto-remove systemd
 
 EXPOSE 22
 CMD ["/run.sh"]


### PR DESCRIPTION
- Debian stretcher is deprecated (EOL)
- iproute is deprecated
- jepsen 0.1.18 has required fixes

We update the above dependencies to make this usable.